### PR TITLE
Fix broken link to the quick-start guide (fixes #51)

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -16,7 +16,7 @@ To set up your very own Pinpoint instance you can either **download the build re
 * **Pinpoint Web** (deployed on a web container)
 * **Pinpoint Agent** (attached to a java application for profiling)
 
-To try out a simple quickstart project, please refer to the [quick-start guide](doc/quickstart.html).
+To try out a simple quickstart project, please refer to the [quick-start guide](./quickstart/README.md).
 
 ### Apple silicon(M1/M2) build failures
 If an error `protoc-gen-grpc-java-1.49.2-osx-aarch_64.exe: program not found or is not executable` occurs in the Apple silicon Mac (M1/M2) development environment, it has to install Rosetta.


### PR DESCRIPTION
Fixed broken link to the quick-start guide in the installation guide.